### PR TITLE
Fix: load cached files

### DIFF
--- a/lib/actions/loadCachedFilesInfo.js
+++ b/lib/actions/loadCachedFilesInfo.js
@@ -8,14 +8,18 @@ const checkForWildcardImports = require("../parsers/checkForWildcardImports");
 
 /**
  * Gera um esquema com os arquivos sendo importados no projeto a partir de um ponto de entrada
- * @param {*} changedFilePath
+ * @param {*} changedFilePath Diretório do arquivo alterado
+ * @param {*} previousFilesInfo Isto é usado quando "loadCachedFilesInfo" é chamado recursivamente,
+ * neste caso ele vai sempre estar com a lista de esquemas atualizadas antes de sofrer o próximo
+ * processo para inserir um arquivo dependente que ainda não tinha sido inserido
  * @returns
  */
-const loadCachedFilesInfo = (changedFilePath) => {
-  // TODO: testar o erro que acontece quando um arquivo é removido do import (resolvido?!)
+const loadCachedFilesInfo = (changedFilePath, previousFilesInfo) => {
   let hasError = null;
   const filesInfoRaw = fs.readFileSync(path.join(`./build/filesInfo.json`));
-  const filesInfo = JSON.parse(filesInfoRaw);
+  const filesInfo = previousFilesInfo
+    ? previousFilesInfo
+    : JSON.parse(filesInfoRaw);
   const changedFileSchema = loadFilesInfo(changedFilePath, true).fileSchemas[0];
 
   // Verifica cada arquivo jsx e ts para ver se estão quebrados ou não.
@@ -50,6 +54,8 @@ const loadCachedFilesInfo = (changedFilePath) => {
   // para mudar o nome deles dentro deste arquivo alterado.
   let changedFileImportsName = {};
 
+  console.log("A", changedFileSchema.toImport);
+
   changedFileSchema.toImport.forEach((toImportFile) => {
     // ex: toImportFile = caminho/arquivo/file.ts
     let toImportSchemaRef = filesInfo.find(
@@ -63,7 +69,10 @@ const loadCachedFilesInfo = (changedFilePath) => {
       // Se nao existir o arquivo no esquema, processa ele para tratar tudo (como nomes)
       // Depois adiciona-o à lista de filesInfo
       // INFO: recursividade
-      const updatedFileSchemasCall = loadCachedFilesInfo(toImportFile);
+      const updatedFileSchemasCall = loadCachedFilesInfo(
+        toImportFile,
+        filesInfo,
+      );
       hasError = updatedFileSchemasCall.hasError;
 
       // Se tiver erro desse processo recursivo, nao segue em frente

--- a/lib/actions/loadCachedFilesInfo.js
+++ b/lib/actions/loadCachedFilesInfo.js
@@ -54,8 +54,6 @@ const loadCachedFilesInfo = (changedFilePath, previousFilesInfo) => {
   // para mudar o nome deles dentro deste arquivo alterado.
   let changedFileImportsName = {};
 
-  console.log("A", changedFileSchema.toImport);
-
   changedFileSchema.toImport.forEach((toImportFile) => {
     // ex: toImportFile = caminho/arquivo/file.ts
     let toImportSchemaRef = filesInfo.find(

--- a/lib/actions/transformSchemaToWidget.js
+++ b/lib/actions/transformSchemaToWidget.js
@@ -355,12 +355,12 @@ const transformWidgetInChildProps = (childProps, fileSchemas) => {
     let entryValue = entry[1];
 
     // Ignora se nao tiver conteúdo JSX
-    if (!entryValue.includes("/>")) {
+    if (typeof entryValue !== "string" || !entryValue.includes("/>")) {
       return;
     }
 
     const foundJSXs = extractJSX(entryValue);
-    if (foundJSXs.length > 0) {
+    if (foundJSXs?.length > 0) {
       foundJSXs.forEach((jsx) => {
         const widgetContent = processChildrenWidget(`<>${jsx}</>`, fileSchemas);
         entryValue = entryValue.replace(jsx, widgetContent);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "alem",
   "description": "Create web3 applications for NEAR BOS with a focus on performance and friendly development.",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "main": "main.js",
   "types": "index.d.ts",
   "author": "Wenderson Pires - wendersonpires.near",


### PR DESCRIPTION
- Fixed issue where new deeper files were not being injected to the file schemas, causing errors during the compilation;
- Fixed issue where widget props was not being executed as string. See here: `transformSchemaToWidget` ⇾ `transformWidgetInChildProps`
- version updated: 1.1.2